### PR TITLE
New prompt line docs and updated cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ Screenshots of theme in [iTerm2](https://iterm2.com/index.html). Using [FiraCode
 >
 > Optionally show clock and exit code.
 
+Screenshots of updated theme in [Konsole](https://apps.kde.org/konsole) using [IBM Plex Mono](https://www.ibm.com/plex/) and [BlexMono](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/IBMPlexMono) for icons.
+
+> ![Screenshot_20240319_101937](https://github.com/win8linux/headline/assets/11584387/8088f029-06ce-4c23-9075-7fd5c18099ae)
+>
+> Status showing `+` for staged changes, `!` for unstaged changes, and `↑` for untracked files (configurable).
+
+> ![Screenshot_20240319_104232](https://github.com/win8linux/headline/assets/11584387/25350ac1-b150-4cdd-8b44-3b236194a966)
+>
+> Optional icons, special font needed (such as BlexMono here).
+
 <br>
 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ More details in **[Terminal Setup](docs/Terminal-Setup.md)**
 ## Screenshots
 Screenshots of theme in [iTerm2](https://iterm2.com/index.html). Using [FiraCode Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode) for continuous line and fancy icons.
 
+**NOTE:** A font with ligatures is no longer required for a continuous line.
+
 > <img src="https://raw.githubusercontent.com/moarram/headline/assets/images/theme-light.png" width="600"/>
 >
 > Status showing `+` for staged changes, `!` for unstaged changes, and `?` for untracked files (configurable).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When enabled with `HEADLINE_DO_CLOCK=true`, display the time to the right of the
 ## Installation
 Download the `headline.zsh-theme` file.
 ```
-$ wget https://raw.githubusercontent.com/moarram/headline/main/headline.zsh-theme
+$ wget https://raw.githubusercontent.com/win8linux/headline/main/headline.zsh-theme
 ```
 
 In your `~/.zshrc`, source the `headline.zsh-theme` file.
@@ -68,7 +68,7 @@ More details in **[Customization](docs/Customization.md)**
 
 
 ## Terminal Setup
-For the continuous line above the prompt, use a font with ligatures such as [Fira Code](https://github.com/tonsky/FiraCode).
+For the continuous line above the prompt, no further setup is needed! Use any font you want, as long as it has the ▁ (Lower One-eighth Block) symbol.
 
 If you want symbols, use a font that has them such as [FiraCode Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode) and assign your desired symbols to the prefix variables.
 

--- a/docs/Terminal-Setup.md
+++ b/docs/Terminal-Setup.md
@@ -5,7 +5,35 @@ The following features depend on terminal settings.
 
 
 ## Continuous Line
-For the continuous separator line above the prompt you need a font with ligatures (and a terminal that supports them). I know [Fira Code](https://github.com/tonsky/FiraCode) works well, but any font that joins adjacent underscores will do. You may need to enable font ligatures in your terminal settings.
+For the continuous separator line above the prompt, you need a font that has the ▁ (`U+2581`) symbol. These are the known compatible fonts:
+
+* IBM Plex Sans
+* Hack
+* Fira Code
+* Anonymous Pro
+* Courier New
+* Fantasque Sans Mono
+* Free Courier
+* FreeMono
+* Hermit
+* Inconsolata
+* Jetrains Mono
+* Latin Modern Mono
+* League Mono
+* Liberation Mono
+* Linux Libertine Mono O
+* Monospace
+* monofur
+* Noto Mono
+* Noto Sans Mono
+* Terminus
+* Ubuntu Mono
+* Andale Mono
+* Courier Prime Code
+* DejaVu Sans Mono
+* IBM 3270
+
+Even if your current font does not have the symbol, it is very likely that you have another font installed which does have it being used as fallback.
 
 <br>
 


### PR DESCRIPTION
Updates documentation to no longer require a font with ligatures to have an uninterrupted prompt line, due to using the ▁ symbol by default. Also updates the documentation to point to this repo and screenshots of the updated theme.